### PR TITLE
Add/spack export to generate standard format of packages and metadata

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -257,7 +257,7 @@ def gray_hash(spec, length):
     return colorize('@K{%s}' % h)
 
 
-def display_specs_as_json(specs, deps=False):
+def get_specs_as_dict(specs, deps=False):
     """Convert specs to a list of json records."""
     seen = set()
     records = []
@@ -273,7 +273,13 @@ def display_specs_as_json(specs, deps=False):
                     continue
                 seen.add(dep.dag_hash())
                 records.append(dep.to_record_dict())
+    return records
 
+
+def display_specs_as_json(specs, deps=False):
+    """Convert specs to a list of json records."""
+
+    records = get_specs_as_dict(specs, deps=deps)
     sjson.dump(records, sys.stdout)
 
 

--- a/lib/spack/spack/cmd/export.py
+++ b/lib/spack/spack/cmd/export.py
@@ -11,7 +11,7 @@ import sys
 import llnl.util.tty as tty
 import spack.repo
 import spack.cmd as cmd
-from spack.cmd.find import query_arguments
+from spack.cmd.find import query_arguments, setup_parser # noqa
 
 import spack.user_environment as uenv
 import spack.util.spack_json as sjson
@@ -69,5 +69,4 @@ def generate_export(results, loaded=False, tags=None, scope=None):
     return {
         "_meta": generate_export_metadata(),
         "specs": cmd.get_specs_as_dict(results, deps=True),
-        "compilers": spack.compilers.all_compilers_list(scope=scope)
     }

--- a/lib/spack/spack/cmd/export.py
+++ b/lib/spack/spack/cmd/export.py
@@ -1,0 +1,73 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from __future__ import print_function
+
+import os
+import sys
+
+import llnl.util.tty as tty
+import spack.repo
+import spack.cmd as cmd
+from spack.cmd.find import query_arguments
+
+import spack.user_environment as uenv
+import spack.util.spack_json as sjson
+
+description = "export installed packages"
+section = "basic"
+level = "short"
+
+
+def export(parser, args):
+    """export is similar to find, except we map packages to an export schema,
+    which also includes compilers and some metadata, and instead of a lookup
+    (dict) of packages, we have a list with an added name attribute
+    """
+    q_args = query_arguments(args)
+    results = args.specs(**q_args)
+
+    # Exit early with an error code if no package matches the constraint
+    if not results and args.constraint:
+        msg = "No packages match the query: {0}"
+        msg = msg.format(' '.join(args.constraint))
+        tty.msg(msg)
+        return 1
+
+    # Generate the export, includes _meta, compilers, specs
+    export = generate_export(
+        results,
+        loaded=args.loaded,
+        tags=args.tags,
+    )
+
+    # Display the result
+    sjson.dump(export, sys.stdout)
+
+
+def generate_export_metadata():
+    return {"spack-version": spack.spack_version}
+
+
+def generate_export(results, loaded=False, tags=None, scope=None):
+    """Generate an export based on the exports.py schema. This means a dict.
+    with keys for compilers, specs, and _meta. A starting set of results
+    must be provided.
+    """
+    # If tags have been specified on the command line, filter by tags
+    if tags:
+        packages_with_tags = spack.repo.path.packages_with_tags(*tags)
+        results = [x for x in results if x.name in packages_with_tags]
+
+    if loaded:
+        hashes = os.environ.get(uenv.spack_loaded_hashes_var, '').split(':')
+        results = [x for x in results if x.dag_hash() in hashes]
+
+    # Include metadata, specs, and compilers
+    return {
+        "_meta": generate_export_metadata(),
+        "specs": cmd.get_specs_as_dict(results, deps=True),
+        "compilers": spack.compilers.all_compilers_list(scope=scope)
+    }

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -285,6 +285,11 @@ def all_compilers(scope=None):
     return compilers
 
 
+def all_compilers_list(scope=None):
+    """A list of compiler dicts, intended for the export schema"""
+    return [_to_dict(c)['compiler'] for c in all_compilers(scope)]
+
+
 @_auto_compiler_spec
 def compilers_for_spec(compiler_spec, arch_spec=None, scope=None,
                        use_cache=True, init_config=True):

--- a/lib/spack/spack/schema/export.py
+++ b/lib/spack/spack/schema/export.py
@@ -12,14 +12,13 @@
 
 from copy import deepcopy
 import spack.schema.spec
-from spack.schema.compilers import properties as compilers
 
 #: name of package must be required for export of list
 package = deepcopy(spack.schema.spec.package)
 package['required'].append('name')
 
 #: A list of specs for packages, and we allow a general _meta section
-specs = {
+properties = {
     'specs': {
         'type': 'array',
         'items': [spack.schema.spec.package]
@@ -28,10 +27,6 @@ specs = {
         'type': 'object'
     }
 }
-
-#: Don't edit specs object in case needed elsewhere
-properties = deepcopy(specs)
-properties.update(compilers)
 
 #: Full schema with metadata
 schema = {

--- a/lib/spack/spack/schema/export.py
+++ b/lib/spack/spack/schema/export.py
@@ -1,0 +1,47 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Schema for a system dump or export of compilers, packages, etc.
+
+.. literalinclude:: _spack_root/lib/spack/spack/schema/export.py
+   :lines: 13-
+"""
+
+
+from copy import deepcopy
+import spack.schema.spec
+from spack.schema.compilers import properties as compilers
+
+# name of package must be required for export of list
+package = deepcopy(spack.schema.spec.package)
+package['required'].append('name')
+
+properties = {
+    'type': 'object',
+    'default': {},
+    'additionalProperties': False,
+    'properties': {
+        'compilers': compilers,
+        'specs': specs,
+    }
+}
+
+# name of package is required for export?
+
+specs = {
+    'specs': {
+        'type': 'array',
+        'items': [spack.schema.spec.package]
+    }
+}
+
+#: Full schema with metadata
+schema = {
+    '$schema': 'http://json-schema.org/schema#',
+    'title': 'Spack export schema',
+    'type': 'object',
+    'additionalProperties': False,
+    'patternProperties': properties,
+}

--- a/lib/spack/spack/schema/export.py
+++ b/lib/spack/spack/schema/export.py
@@ -14,34 +14,30 @@ from copy import deepcopy
 import spack.schema.spec
 from spack.schema.compilers import properties as compilers
 
-# name of package must be required for export of list
+#: name of package must be required for export of list
 package = deepcopy(spack.schema.spec.package)
 package['required'].append('name')
 
-properties = {
-    'type': 'object',
-    'default': {},
-    'additionalProperties': False,
-    'properties': {
-        'compilers': compilers,
-        'specs': specs,
-    }
-}
-
-# name of package is required for export?
-
+#: A list of specs for packages, and we allow a general _meta section
 specs = {
     'specs': {
         'type': 'array',
         'items': [spack.schema.spec.package]
+    },
+    "_meta": {
+        'type': 'object'
     }
 }
 
+#: Don't edit specs object in case needed elsewhere
+properties = deepcopy(specs)
+properties.update(compilers)
+
 #: Full schema with metadata
 schema = {
-    '$schema': 'http://json-schema.org/schema#',
+    '$schema': 'https://json-schema.org/schema#',
     'title': 'Spack export schema',
     'type': 'object',
     'additionalProperties': False,
-    'patternProperties': properties,
+    'properties': properties,
 }

--- a/lib/spack/spack/schema/spec.py
+++ b/lib/spack/spack/schema/spec.py
@@ -67,9 +67,7 @@ dependencies = {
     },
 }
 
-#: Properties for inclusion in other schemas
-properties = {
-    r'\w[\w-]*': {  # package name
+package = {
         'type': 'object',
         'additionalProperties': False,
         'required': [
@@ -80,6 +78,10 @@ properties = {
             'parameters',
         ],
         'properties': {
+            'name': {
+                'type': 'string',
+                'pattern': r'\w[\w-]*',
+             },
             'hash': {'type': 'string'},
             'full_hash': {'type': 'string'},
             'version': {
@@ -152,7 +154,12 @@ properties = {
             },
             'dependencies': dependencies,
         },
-    },
+    }
+
+#: Properties for inclusion in other schemas
+properties = {
+    # package name
+    r'\w[\w-]*': package
 }
 
 

--- a/lib/spack/spack/schema/spec.py
+++ b/lib/spack/spack/schema/spec.py
@@ -68,93 +68,55 @@ dependencies = {
 }
 
 package = {
-        'type': 'object',
-        'additionalProperties': False,
-        'required': [
-            'version',
-            'arch',
-            'compiler',
-            'namespace',
-            'parameters',
-        ],
-        'properties': {
-            'name': {
-                'type': 'string',
-                'pattern': r'\w[\w-]*',
-             },
-            'hash': {'type': 'string'},
-            'full_hash': {'type': 'string'},
-            'version': {
-                'oneOf': [
-                    {'type': 'string'},
-                    {'type': 'number'},
-                ],
-            },
-            'arch': arch,
-            'compiler': {
-                'type': 'object',
-                'additionalProperties': False,
-                'properties': {
-                    'name': {'type': 'string'},
-                    'version': {'type': 'string'},
-                },
-            },
-            'develop': {
-                'anyOf': [
-                    {'type': 'boolean'},
-                    {'type': 'string'},
-                ],
-            },
-            'namespace': {'type': 'string'},
-            'parameters': {
-                'type': 'object',
-                'required': [
-                    'cflags',
-                    'cppflags',
-                    'cxxflags',
-                    'fflags',
-                    'ldflags',
-                    'ldlibs',
-                ],
-                'additionalProperties': True,
-                'properties': {
-                    'patches': {
-                        'type': 'array',
-                        'items': {'type': 'string'},
-                    },
-                    'cflags': {
-                        'type': 'array',
-                        'items': {'type': 'string'},
-                    },
-                    'cppflags': {
-                        'type': 'array',
-                        'items': {'type': 'string'},
-                    },
-                    'cxxflags': {
-                        'type': 'array',
-                        'items': {'type': 'string'},
-                    },
-                    'fflags': {
-                        'type': 'array',
-                        'items': {'type': 'string'},
-                    },
-                    'ldflags': {
-                        'type': 'array',
-                        'items': {'type': 'string'},
-                    },
-                    'ldlib': {
-                        'type': 'array',
-                        'items': {'type': 'string'},
-                    },
-                },
-            },
-            'patches': {
-                'type': 'array',
-                'items': {},
-            },
-            'dependencies': dependencies,
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["version", "arch", "compiler", "namespace", "parameters"],
+    "properties": {
+        "name": {"type": "string", "pattern": r"\w[\w-]*"},
+        "hash": {"type": "string"},
+        "prefix": {"type": "string"},
+        "full_hash": {"type": "string"},
+        "version": {"oneOf": [{"type": "string"}, {"type": "number"}]},
+        "arch": arch,
+        "compiler": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "name": {"type": "string"}, "version": {"type": "string"}},
         },
-    }
+        "source": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "name": {"type": "string"}, "filename": {"type": "string"}},
+        },
+        "develop": {"anyOf": [{"type": "boolean"}, {"type": "string"}]},
+        "namespace": {"type": "string"},
+        "parameters": {
+            "type": "object",
+            "required": [
+                "cflags",
+                "cppflags",
+                "cxxflags",
+                "fflags",
+                "ldflags",
+                "ldlibs",
+            ],
+            "additionalProperties": True,
+            "properties": {
+                "patches": {"type": "array", "items": {"type": "string"}},
+                "cflags": {"type": "array", "items": {"type": "string"}},
+                "cppflags": {"type": "array", "items": {"type": "string"}},
+                "cxxflags": {"type": "array", "items": {"type": "string"}},
+                "fflags": {"type": "array", "items": {"type": "string"}},
+                "ldflags": {"type": "array", "items": {"type": "string"}},
+                "ldlib": {"type": "array", "items": {"type": "string"}},
+            },
+        },
+        "patches": {"type": "array", "items": {}},
+        "dependencies": dependencies,
+    },
+}
 
 #: Properties for inclusion in other schemas
 properties = {

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1481,42 +1481,64 @@ class Spec(object):
         return base32_prefix_bits(self.dag_hash(), bits)
 
     def to_node_dict(self, hash=ht.dag_hash):
-        """Create a dictionary representing the state of this Spec.
+        """Create a dictionary representing the state of this Spec. Empty
+           values (e.g., compiler parameters) are not included.
 
         ``to_node_dict`` creates the content that is eventually hashed by
         Spack to create identifiers like the DAG hash (see
-        ``dag_hash()``).  Example result of ``to_node_dict`` for the
-        ``sqlite`` package::
+        ``dag_hash()``).  Example (truncated) result of ``to_node_dict``
+        for the ``sqlite`` package::
 
             {
-                'sqlite': {
-                    'version': '3.28.0',
-                    'arch': {
-                        'platform': 'darwin',
-                        'platform_os': 'mojave',
-                        'target': 'x86_64',
+                "version": "3.33.0",
+                "arch": {
+                    "platform": "linux",
+                    "platform_os": "ubuntu18.04",
+                    "target": {
+                        "name": "skylake",
+                        "vendor": "GenuineIntel",
+                        "features": [
+                            "adx",
+                            "aes",
+                            "avx",
+                            ...
+                            "ssse3",
+                            "xsavec",
+                            "xsaveopt"
+                        ],
+                        "generation": 0,
+                        "parents": [
+                            "broadwell"
+                        ]
+                    }
+                },            
+                "compiler": {            
+                    "name": "gvcc",
+                    "version": "7.5.0"
+                },
+                "namespace": "builtin",
+                "parameters": {
+                    "column_metadata": true,
+                    "fts": true,
+                    "functions": false,
+                    "rtree": false
+                },
+                "prefix": "...sqlite-3.33.0-542j4smsc2j3jkjowrebyc5s77kna4d4",
+                "dependencies": {
+                    "readline": {
+                        "hash": "l3bzhbkekxg3ggeov4cjh3gaj5jdplet",
+                        "type": [
+                            "build",
+                            "link"
+                        ]
                     },
-                    'compiler': {
-                        'name': 'apple-clang',
-                        'version': '10.0.0',
-                    },
-                    'namespace': 'builtin',
-                    'parameters': {
-                        'fts': 'true',
-                        'functions': 'false',
-                        'cflags': [],
-                        'cppflags': [],
-                        'cxxflags': [],
-                        'fflags': [],
-                        'ldflags': [],
-                        'ldlibs': [],
-                    },
-                    'dependencies': {
-                        'readline': {
-                            'hash': 'zvaa4lhlhilypw5quj3akyd3apbq5gap',
-                            'type': ['build', 'link'],
-                        }
-                    },
+                    "zlib": {
+                        "hash": "fz2bs562jhc2spgubs3fvq25g3qymz6x",
+                        "type": [
+                            "build",
+                            "link"
+                        ]
+                    }
                 }
             }
 
@@ -1552,7 +1574,8 @@ class Spec(object):
             )
         )
 
-        params.update(sorted(self.compiler_flags.items()))
+        # Only add compilers params if they aren't empty
+        params.update(sorted(x for x in self.compiler_flags.items() if x[1]))
         if params:
             d['parameters'] = params
 
@@ -1562,6 +1585,9 @@ class Spec(object):
                 ('module', self.external_modules),
                 ('extra_attributes', self.extra_attributes)
             ])
+
+        if self.prefix:
+            d['prefix'] = self.prefix
 
         if not self._concrete:
             d['concrete'] = False


### PR DESCRIPTION
Hey @tgamblin! This pull request is primarily for discussion, and let me know if I should be pinging others that are interested as well. The goal is to make it easy to export a json file with:

 - compilers
 - package specs
 - metadata

So I added a new schema, export.py, that primarily uses other schemas (spec.py and compilers.py) to create a simple data structure with those three entities. This structure is then exposed via the export.py command. Some questions that I had:

```bash
spack export
```
will print this in the console, a derivative of the example provided (that still needs a bit of work, but it's a start!)

<details>

<summary>JSON export example</summary>

```json
$ bin/spack export
{
 "_meta": {
  "spack-version": "0.16.0"
 },
 "specs": [
  {
   "name": "autoconf",
   "hash": "dxo5g7zayxrtg4wex6fqcixgmfywuiie",
   "version": "2.69",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   },
   "dependencies": {
    "m4": {
     "hash": "erqdtam4yfnuwhwzmk2n5u4wbwcb5wkv",
     "type": [
      "build",
      "run"
     ]
    },
    "perl": {
     "hash": "3fjpn4jzos5iut7cvjqbngo3imtxbosn",
     "type": [
      "build",
      "run"
     ]
    }
   }
  },
  {
   "name": "m4",
   "hash": "erqdtam4yfnuwhwzmk2n5u4wbwcb5wkv",
   "version": "1.4.18",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "patches": [
     "3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00",
     "fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8"
    ],
    "sigsegv": true,
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   },
   "patches": [
    "3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00",
    "fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8"
   ],
   "dependencies": {
    "libsigsegv": {
     "hash": "aymspclv5aqdkwqkxvlxxerrimgsjzd2",
     "type": [
      "build",
      "link"
     ]
    }
   }
  },
  {
   "name": "libsigsegv",
   "hash": "aymspclv5aqdkwqkxvlxxerrimgsjzd2",
   "version": "2.12",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   }
  },
  {
   "name": "perl",
   "hash": "3fjpn4jzos5iut7cvjqbngo3imtxbosn",
   "version": "5.32.0",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "cpanm": true,
    "shared": true,
    "threads": true,
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   },
   "dependencies": {
    "berkeley-db": {
     "hash": "xrzi3qjouewrl7vgf7hfl42xcwcptryi",
     "type": [
      "build",
      "link"
     ]
    },
    "gdbm": {
     "hash": "a3onxbk63mvypoeocklamcj3q7jcyfyj",
     "type": [
      "build",
      "link"
     ]
    }
   }
  },
  {
   "name": "berkeley-db",
   "hash": "xrzi3qjouewrl7vgf7hfl42xcwcptryi",
   "version": "18.1.40",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   }
  },
  {
   "name": "gdbm",
   "hash": "a3onxbk63mvypoeocklamcj3q7jcyfyj",
   "version": "1.18.1",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   },
   "dependencies": {
    "readline": {
     "hash": "l3bzhbkekxg3ggeov4cjh3gaj5jdplet",
     "type": [
      "build",
      "link"
     ]
    }
   }
  },
  {
   "name": "readline",
   "hash": "l3bzhbkekxg3ggeov4cjh3gaj5jdplet",
   "version": "8.0",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   },
   "dependencies": {
    "ncurses": {
     "hash": "nlvmejfn4n7jkkot2nglflrtwpu56o27",
     "type": [
      "build",
      "link"
     ]
    }
   }
  },
  {
   "name": "ncurses",
   "hash": "nlvmejfn4n7jkkot2nglflrtwpu56o27",
   "version": "6.2",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "symlinks": false,
    "termlib": true,
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   }
  },
  {
   "name": "automake",
   "hash": "6nzwwofj7xewjf4pfiudu5mvksmhi6o2",
   "version": "1.16.2",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   },
   "dependencies": {
    "perl": {
     "hash": "3fjpn4jzos5iut7cvjqbngo3imtxbosn",
     "type": [
      "build",
      "run"
     ]
    }
   }
  },
  {
   "name": "bzip2",
   "hash": "yjwcvti7ehjkvqcu67rdzymdawi6nruk",
   "version": "1.0.8",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "shared": true,
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   }
  },
  {
   "name": "diffutils",
   "hash": "624pjac4maorpjwa4kl7ydasl5jy7wgy",
   "version": "3.7",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   },
   "dependencies": {
    "libiconv": {
     "hash": "7ddqjmff6zg3zer572yuqnvzk2ebrkfc",
     "type": [
      "build",
      "link"
     ]
    }
   }
  },
  {
   "name": "libiconv",
   "hash": "7ddqjmff6zg3zer572yuqnvzk2ebrkfc",
   "version": "1.16",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   }
  },
  {
   "name": "expat",
   "hash": "ed6encylyziniuvvqtbsunmztze3s5s2",
   "version": "2.2.10",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "libbsd": true,
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   },
   "dependencies": {
    "libbsd": {
     "hash": "gvadyz7pk4n6zmbn2kepfwjgdfc6yr2x",
     "type": [
      "build",
      "link"
     ]
    }
   }
  },
  {
   "name": "libbsd",
   "hash": "gvadyz7pk4n6zmbn2kepfwjgdfc6yr2x",
   "version": "0.10.0",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   }
  },
  {
   "name": "gettext",
   "hash": "xkjvfgvpeoxcdckiha765ntqppsftzmg",
   "version": "0.21",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "bzip2": true,
    "curses": true,
    "git": true,
    "libunistring": false,
    "libxml2": true,
    "tar": true,
    "xz": true,
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   },
   "dependencies": {
    "bzip2": {
     "hash": "yjwcvti7ehjkvqcu67rdzymdawi6nruk",
     "type": [
      "build",
      "link"
     ]
    },
    "libiconv": {
     "hash": "7ddqjmff6zg3zer572yuqnvzk2ebrkfc",
     "type": [
      "build",
      "link"
     ]
    },
    "libxml2": {
     "hash": "hxsopl6whqtirosqzu4blc3urkyeryhk",
     "type": [
      "build",
      "link"
     ]
    },
    "ncurses": {
     "hash": "nlvmejfn4n7jkkot2nglflrtwpu56o27",
     "type": [
      "build",
      "link"
     ]
    },
    "tar": {
     "hash": "2gudv7nnasphqr6zwrvoulakgqkfnbha",
     "type": [
      "build",
      "link"
     ]
    },
    "xz": {
     "hash": "yjkcmisqyqjpfqwa4cvll5qehkr25aog",
     "type": [
      "build",
      "link",
      "run"
     ]
    }
   }
  },
  {
   "name": "libxml2",
   "hash": "hxsopl6whqtirosqzu4blc3urkyeryhk",
   "version": "2.9.10",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "python": false,
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   },
   "dependencies": {
    "libiconv": {
     "hash": "7ddqjmff6zg3zer572yuqnvzk2ebrkfc",
     "type": [
      "build",
      "link"
     ]
    },
    "xz": {
     "hash": "yjkcmisqyqjpfqwa4cvll5qehkr25aog",
     "type": [
      "build",
      "link"
     ]
    },
    "zlib": {
     "hash": "fz2bs562jhc2spgubs3fvq25g3qymz6x",
     "type": [
      "build",
      "link"
     ]
    }
   }
  },
  {
   "name": "xz",
   "hash": "yjkcmisqyqjpfqwa4cvll5qehkr25aog",
   "version": "5.2.5",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "pic": false,
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   }
  },
  {
   "name": "zlib",
   "hash": "fz2bs562jhc2spgubs3fvq25g3qymz6x",
   "version": "1.2.11",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "optimize": true,
    "pic": true,
    "shared": true,
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   }
  },
  {
   "name": "tar",
   "hash": "2gudv7nnasphqr6zwrvoulakgqkfnbha",
   "version": "1.32",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   },
   "dependencies": {
    "libiconv": {
     "hash": "7ddqjmff6zg3zer572yuqnvzk2ebrkfc",
     "type": [
      "build",
      "link"
     ]
    }
   }
  },
  {
   "name": "hwloc",
   "hash": "bvnla66dlfde4hxcs7rxtpigyscxfosa",
   "version": "1.11.11",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "cairo": false,
    "cuda": false,
    "gl": false,
    "libudev": false,
    "libxml2": true,
    "netloc": false,
    "nvml": false,
    "pci": true,
    "shared": true,
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   },
   "dependencies": {
    "libpciaccess": {
     "hash": "fyllhvy7teorlwvdy2sqtpooxlwjrniv",
     "type": [
      "build",
      "link"
     ]
    },
    "libxml2": {
     "hash": "hxsopl6whqtirosqzu4blc3urkyeryhk",
     "type": [
      "build",
      "link"
     ]
    },
    "numactl": {
     "hash": "whvewr7rzd4pjpcruu3qeyr5hxmigwt4",
     "type": [
      "build",
      "link"
     ]
    }
   }
  },
  {
   "name": "libpciaccess",
   "hash": "fyllhvy7teorlwvdy2sqtpooxlwjrniv",
   "version": "0.16",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   }
  },
  {
   "name": "numactl",
   "hash": "whvewr7rzd4pjpcruu3qeyr5hxmigwt4",
   "version": "2.0.14",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "patches": [
     "4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94"
    ],
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   },
   "patches": [
    "4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94"
   ]
  },
  {
   "name": "libffi",
   "hash": "fx25vf5v4ascytgovndkyubz3edmi3ua",
   "version": "3.3",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "patches": [
     "26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0"
    ],
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   },
   "patches": [
    "26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0"
   ]
  },
  {
   "name": "libtool",
   "hash": "oljw33wi4jixtfxnwe56rijcmgw3t4o4",
   "version": "2.4.6",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   }
  },
  {
   "name": "libuuid",
   "hash": "zmp24y7n3vlc6nf5fkgjhnkskcqgkxti",
   "version": "1.0.3",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   }
  },
  {
   "name": "openssl",
   "hash": "x2nzurqswjj6yewwmt4ksistiikduscn",
   "version": "1.1.1i",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "systemcerts": true,
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   },
   "dependencies": {
    "zlib": {
     "hash": "fz2bs562jhc2spgubs3fvq25g3qymz6x",
     "type": [
      "build",
      "link"
     ]
    }
   }
  },
  {
   "name": "pkgconf",
   "hash": "wicmqmx5hlx35fzdgmxs2thnjloasw7q",
   "version": "1.7.3",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   }
  },
  {
   "name": "python",
   "hash": "xzlv5l2ex5x4xcgjdqbmtqub2aog3t4o",
   "version": "3.8.6",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "bz2": true,
    "ctypes": true,
    "dbm": true,
    "debug": false,
    "libxml2": true,
    "lzma": true,
    "nis": false,
    "optimizations": false,
    "patches": [
     "0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87"
    ],
    "pic": true,
    "pyexpat": true,
    "pythoncmd": true,
    "readline": true,
    "shared": true,
    "sqlite3": true,
    "ssl": true,
    "tix": false,
    "tkinter": false,
    "ucs4": false,
    "uuid": true,
    "zlib": true,
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   },
   "patches": [
    "0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87"
   ],
   "dependencies": {
    "bzip2": {
     "hash": "yjwcvti7ehjkvqcu67rdzymdawi6nruk",
     "type": [
      "build",
      "link"
     ]
    },
    "expat": {
     "hash": "ed6encylyziniuvvqtbsunmztze3s5s2",
     "type": [
      "build",
      "link"
     ]
    },
    "gdbm": {
     "hash": "a3onxbk63mvypoeocklamcj3q7jcyfyj",
     "type": [
      "build",
      "link"
     ]
    },
    "gettext": {
     "hash": "xkjvfgvpeoxcdckiha765ntqppsftzmg",
     "type": [
      "build",
      "link"
     ]
    },
    "libffi": {
     "hash": "fx25vf5v4ascytgovndkyubz3edmi3ua",
     "type": [
      "build",
      "link"
     ]
    },
    "libuuid": {
     "hash": "zmp24y7n3vlc6nf5fkgjhnkskcqgkxti",
     "type": [
      "build",
      "link"
     ]
    },
    "ncurses": {
     "hash": "nlvmejfn4n7jkkot2nglflrtwpu56o27",
     "type": [
      "build",
      "link"
     ]
    },
    "openssl": {
     "hash": "x2nzurqswjj6yewwmt4ksistiikduscn",
     "type": [
      "build",
      "link"
     ]
    },
    "readline": {
     "hash": "l3bzhbkekxg3ggeov4cjh3gaj5jdplet",
     "type": [
      "build",
      "link"
     ]
    },
    "sqlite": {
     "hash": "542j4smsc2j3jkjowrebyc5s77kna4d4",
     "type": [
      "build",
      "link"
     ]
    },
    "xz": {
     "hash": "yjkcmisqyqjpfqwa4cvll5qehkr25aog",
     "type": [
      "build",
      "link"
     ]
    },
    "zlib": {
     "hash": "fz2bs562jhc2spgubs3fvq25g3qymz6x",
     "type": [
      "build",
      "link"
     ]
    }
   }
  },
  {
   "name": "sqlite",
   "hash": "542j4smsc2j3jkjowrebyc5s77kna4d4",
   "version": "3.33.0",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "column_metadata": true,
    "fts": true,
    "functions": false,
    "rtree": false,
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   },
   "dependencies": {
    "readline": {
     "hash": "l3bzhbkekxg3ggeov4cjh3gaj5jdplet",
     "type": [
      "build",
      "link"
     ]
    },
    "zlib": {
     "hash": "fz2bs562jhc2spgubs3fvq25g3qymz6x",
     "type": [
      "build",
      "link"
     ]
    }
   }
  },
  {
   "name": "util-macros",
   "hash": "se2a2e74oyusj2r4esgcb7pr3qhh45ef",
   "version": "1.19.1",
   "arch": {
    "platform": "linux",
    "platform_os": "ubuntu18.04",
    "target": {
     "name": "skylake",
     "vendor": "GenuineIntel",
     "features": [
      "adx",
      "aes",
      "avx",
      "avx2",
      "bmi1",
      "bmi2",
      "clflushopt",
      "f16c",
      "fma",
      "mmx",
      "movbe",
      "pclmulqdq",
      "popcnt",
      "rdrand",
      "rdseed",
      "sse",
      "sse2",
      "sse4_1",
      "sse4_2",
      "ssse3",
      "xsavec",
      "xsaveopt"
     ],
     "generation": 0,
     "parents": [
      "broadwell"
     ]
    }
   },
   "compiler": {
    "name": "gcc",
    "version": "7.5.0"
   },
   "namespace": "builtin",
   "parameters": {
    "cflags": [],
    "cppflags": [],
    "cxxflags": [],
    "fflags": [],
    "ldflags": [],
    "ldlibs": []
   }
  }
 ],
 "compilers": [
  {
   "spec": "gcc@7.5.0",
   "paths": {
    "cc": "/usr/bin/gcc",
    "cxx": "/usr/bin/g++",
    "f77": null,
    "fc": null
   },
   "flags": {},
   "operating_system": "ubuntu18.04",
   "target": "x86_64",
   "modules": [],
   "environment": {},
   "extra_rpaths": []
  }
 ]
}
```

</details>

<details>

<summary>YAML example</summary>

Not implemented yet, but just to show.
```yaml
---
_meta:
  spack-version: 0.16.0
specs:
- name: autoconf
  hash: dxo5g7zayxrtg4wex6fqcixgmfywuiie
  version: '2.69'
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
  dependencies:
    m4:
      hash: erqdtam4yfnuwhwzmk2n5u4wbwcb5wkv
      type:
      - build
      - run
    perl:
      hash: 3fjpn4jzos5iut7cvjqbngo3imtxbosn
      type:
      - build
      - run
- name: m4
  hash: erqdtam4yfnuwhwzmk2n5u4wbwcb5wkv
  version: 1.4.18
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    patches:
    - 3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00
    - fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8
    sigsegv: true
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
  patches:
  - 3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00
  - fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8
  dependencies:
    libsigsegv:
      hash: aymspclv5aqdkwqkxvlxxerrimgsjzd2
      type:
      - build
      - link
- name: libsigsegv
  hash: aymspclv5aqdkwqkxvlxxerrimgsjzd2
  version: '2.12'
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
- name: perl
  hash: 3fjpn4jzos5iut7cvjqbngo3imtxbosn
  version: 5.32.0
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    cpanm: true
    shared: true
    threads: true
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
  dependencies:
    berkeley-db:
      hash: xrzi3qjouewrl7vgf7hfl42xcwcptryi
      type:
      - build
      - link
    gdbm:
      hash: a3onxbk63mvypoeocklamcj3q7jcyfyj
      type:
      - build
      - link
- name: berkeley-db
  hash: xrzi3qjouewrl7vgf7hfl42xcwcptryi
  version: 18.1.40
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
- name: gdbm
  hash: a3onxbk63mvypoeocklamcj3q7jcyfyj
  version: 1.18.1
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
  dependencies:
    readline:
      hash: l3bzhbkekxg3ggeov4cjh3gaj5jdplet
      type:
      - build
      - link
- name: readline
  hash: l3bzhbkekxg3ggeov4cjh3gaj5jdplet
  version: '8.0'
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
  dependencies:
    ncurses:
      hash: nlvmejfn4n7jkkot2nglflrtwpu56o27
      type:
      - build
      - link
- name: ncurses
  hash: nlvmejfn4n7jkkot2nglflrtwpu56o27
  version: '6.2'
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    symlinks: false
    termlib: true
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
- name: automake
  hash: 6nzwwofj7xewjf4pfiudu5mvksmhi6o2
  version: 1.16.2
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
  dependencies:
    perl:
      hash: 3fjpn4jzos5iut7cvjqbngo3imtxbosn
      type:
      - build
      - run
- name: bzip2
  hash: yjwcvti7ehjkvqcu67rdzymdawi6nruk
  version: 1.0.8
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    shared: true
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
- name: diffutils
  hash: 624pjac4maorpjwa4kl7ydasl5jy7wgy
  version: '3.7'
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
  dependencies:
    libiconv:
      hash: 7ddqjmff6zg3zer572yuqnvzk2ebrkfc
      type:
      - build
      - link
- name: libiconv
  hash: 7ddqjmff6zg3zer572yuqnvzk2ebrkfc
  version: '1.16'
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
- name: expat
  hash: ed6encylyziniuvvqtbsunmztze3s5s2
  version: 2.2.10
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    libbsd: true
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
  dependencies:
    libbsd:
      hash: gvadyz7pk4n6zmbn2kepfwjgdfc6yr2x
      type:
      - build
      - link
- name: libbsd
  hash: gvadyz7pk4n6zmbn2kepfwjgdfc6yr2x
  version: 0.10.0
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
- name: gettext
  hash: xkjvfgvpeoxcdckiha765ntqppsftzmg
  version: '0.21'
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    bzip2: true
    curses: true
    git: true
    libunistring: false
    libxml2: true
    tar: true
    xz: true
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
  dependencies:
    bzip2:
      hash: yjwcvti7ehjkvqcu67rdzymdawi6nruk
      type:
      - build
      - link
    libiconv:
      hash: 7ddqjmff6zg3zer572yuqnvzk2ebrkfc
      type:
      - build
      - link
    libxml2:
      hash: hxsopl6whqtirosqzu4blc3urkyeryhk
      type:
      - build
      - link
    ncurses:
      hash: nlvmejfn4n7jkkot2nglflrtwpu56o27
      type:
      - build
      - link
    tar:
      hash: 2gudv7nnasphqr6zwrvoulakgqkfnbha
      type:
      - build
      - link
    xz:
      hash: yjkcmisqyqjpfqwa4cvll5qehkr25aog
      type:
      - build
      - link
      - run
- name: libxml2
  hash: hxsopl6whqtirosqzu4blc3urkyeryhk
  version: 2.9.10
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    python: false
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
  dependencies:
    libiconv:
      hash: 7ddqjmff6zg3zer572yuqnvzk2ebrkfc
      type:
      - build
      - link
    xz:
      hash: yjkcmisqyqjpfqwa4cvll5qehkr25aog
      type:
      - build
      - link
    zlib:
      hash: fz2bs562jhc2spgubs3fvq25g3qymz6x
      type:
      - build
      - link
- name: xz
  hash: yjkcmisqyqjpfqwa4cvll5qehkr25aog
  version: 5.2.5
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    pic: false
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
- name: zlib
  hash: fz2bs562jhc2spgubs3fvq25g3qymz6x
  version: 1.2.11
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    optimize: true
    pic: true
    shared: true
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
- name: tar
  hash: 2gudv7nnasphqr6zwrvoulakgqkfnbha
  version: '1.32'
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
  dependencies:
    libiconv:
      hash: 7ddqjmff6zg3zer572yuqnvzk2ebrkfc
      type:
      - build
      - link
- name: hwloc
  hash: bvnla66dlfde4hxcs7rxtpigyscxfosa
  version: 1.11.11
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    cairo: false
    cuda: false
    gl: false
    libudev: false
    libxml2: true
    netloc: false
    nvml: false
    pci: true
    shared: true
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
  dependencies:
    libpciaccess:
      hash: fyllhvy7teorlwvdy2sqtpooxlwjrniv
      type:
      - build
      - link
    libxml2:
      hash: hxsopl6whqtirosqzu4blc3urkyeryhk
      type:
      - build
      - link
    numactl:
      hash: whvewr7rzd4pjpcruu3qeyr5hxmigwt4
      type:
      - build
      - link
- name: libpciaccess
  hash: fyllhvy7teorlwvdy2sqtpooxlwjrniv
  version: '0.16'
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
- name: numactl
  hash: whvewr7rzd4pjpcruu3qeyr5hxmigwt4
  version: 2.0.14
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    patches:
    - 4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
  patches:
  - 4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94
- name: libffi
  hash: fx25vf5v4ascytgovndkyubz3edmi3ua
  version: '3.3'
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    patches:
    - 26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
  patches:
  - 26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0
- name: libtool
  hash: oljw33wi4jixtfxnwe56rijcmgw3t4o4
  version: 2.4.6
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
- name: libuuid
  hash: zmp24y7n3vlc6nf5fkgjhnkskcqgkxti
  version: 1.0.3
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
- name: openssl
  hash: x2nzurqswjj6yewwmt4ksistiikduscn
  version: 1.1.1i
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    systemcerts: true
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
  dependencies:
    zlib:
      hash: fz2bs562jhc2spgubs3fvq25g3qymz6x
      type:
      - build
      - link
- name: pkgconf
  hash: wicmqmx5hlx35fzdgmxs2thnjloasw7q
  version: 1.7.3
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
- name: python
  hash: xzlv5l2ex5x4xcgjdqbmtqub2aog3t4o
  version: 3.8.6
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    bz2: true
    ctypes: true
    dbm: true
    debug: false
    libxml2: true
    lzma: true
    nis: false
    optimizations: false
    patches:
    - 0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87
    pic: true
    pyexpat: true
    pythoncmd: true
    readline: true
    shared: true
    sqlite3: true
    ssl: true
    tix: false
    tkinter: false
    ucs4: false
    uuid: true
    zlib: true
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
  patches:
  - 0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87
  dependencies:
    bzip2:
      hash: yjwcvti7ehjkvqcu67rdzymdawi6nruk
      type:
      - build
      - link
    expat:
      hash: ed6encylyziniuvvqtbsunmztze3s5s2
      type:
      - build
      - link
    gdbm:
      hash: a3onxbk63mvypoeocklamcj3q7jcyfyj
      type:
      - build
      - link
    gettext:
      hash: xkjvfgvpeoxcdckiha765ntqppsftzmg
      type:
      - build
      - link
    libffi:
      hash: fx25vf5v4ascytgovndkyubz3edmi3ua
      type:
      - build
      - link
    libuuid:
      hash: zmp24y7n3vlc6nf5fkgjhnkskcqgkxti
      type:
      - build
      - link
    ncurses:
      hash: nlvmejfn4n7jkkot2nglflrtwpu56o27
      type:
      - build
      - link
    openssl:
      hash: x2nzurqswjj6yewwmt4ksistiikduscn
      type:
      - build
      - link
    readline:
      hash: l3bzhbkekxg3ggeov4cjh3gaj5jdplet
      type:
      - build
      - link
    sqlite:
      hash: 542j4smsc2j3jkjowrebyc5s77kna4d4
      type:
      - build
      - link
    xz:
      hash: yjkcmisqyqjpfqwa4cvll5qehkr25aog
      type:
      - build
      - link
    zlib:
      hash: fz2bs562jhc2spgubs3fvq25g3qymz6x
      type:
      - build
      - link
- name: sqlite
  hash: 542j4smsc2j3jkjowrebyc5s77kna4d4
  version: 3.33.0
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    column_metadata: true
    fts: true
    functions: false
    rtree: false
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
  dependencies:
    readline:
      hash: l3bzhbkekxg3ggeov4cjh3gaj5jdplet
      type:
      - build
      - link
    zlib:
      hash: fz2bs562jhc2spgubs3fvq25g3qymz6x
      type:
      - build
      - link
- name: util-macros
  hash: se2a2e74oyusj2r4esgcb7pr3qhh45ef
  version: 1.19.1
  arch:
    platform: linux
    platform_os: ubuntu18.04
    target:
      name: skylake
      vendor: GenuineIntel
      features:
      - adx
      - aes
      - avx
      - avx2
      - bmi1
      - bmi2
      - clflushopt
      - f16c
      - fma
      - mmx
      - movbe
      - pclmulqdq
      - popcnt
      - rdrand
      - rdseed
      - sse
      - sse2
      - sse4_1
      - sse4_2
      - ssse3
      - xsavec
      - xsaveopt
      generation: 0
      parents:
      - broadwell
  compiler:
    name: gcc
    version: 7.5.0
  namespace: builtin
  parameters:
    cflags: []
    cppflags: []
    cxxflags: []
    fflags: []
    ldflags: []
    ldlibs: []
compilers:
- spec: gcc@7.5.0
  paths:
    cc: "/usr/bin/gcc"
    cxx: "/usr/bin/g++"
    f77:
    fc:
  flags: {}
  operating_system: ubuntu18.04
  target: x86_64
  modules: []
  environment: {}
  extra_rpaths: []
```
</details>

## Questions
1. Is this even the right approach? My thinking was that we would want to preserve (as much as possible) the current schemas that spack has. For this reason, although the example that I was deriving this from was different (e.g., it had an arch section with os instead of just `operating_system`), using `executables` instead of `paths`, and an additional "prefix" section). for this first go I tried to maintain what is currently in spack as much as possible. Also, it looks like the example has null or empty values removed (which I haven't done). Should we do this, and if yes, on the level of the export function, or at the level of the spec/compiler?
2. The example provided an `rpm` attribute that looks like the package file, and I didn't add this yet. We can either go with something like `source` with nested values, or do the same as the example, a flat `rpm` (and other sources) at the top level. e.g., `{"source": {"name": "RPM", "filename": "fftw-2.1.5.9-3.x86_64.rpm"}}`
3. Once the format is reasonable, what detail work is needed? (e.g., you mentioned resolving externals). I was also thinking that if the centers producing the examples have particular tricks for generating the files, maybe we should ask them how they do it?

## TODO

1. The current argument parser is taken from find, and I expect that we would want to customize it to provide some additional arguments (e.g., saving to file). We should discuss what we want the argparser here to export.
2. I didn't quite look into the functionality of spack.environment, which I saw scattered around command scripts. Do we need that here?
3. Eventually, the metadata section should allow for custom metadata. I currently just put the spack version. But perhaps we should also add a date when generated?
4. Also in terms of customization, it should be easy for a center to add some custom entry derived from a script or file. 
5. Eventually we will want to add something about ABI compatability, 
6. I don't have docs yet, but I can put these together when it's more developed
7. I also don't actually use the schema to validate the data structure, we can add that in after.

And thinking about this, if this file can describe all packages and compilers and some metadata, it could be used as input for not just spack/tools, but also for cool visualizations! Apologies in advance for any or all oversights that I've had in putting this together, I'm fairly new to this part of spack so I'm pretty happy that I at least found what I was looking for :laughing: 
